### PR TITLE
Rename 'class variables' to 'instance variables'

### DIFF
--- a/index.md
+++ b/index.md
@@ -105,7 +105,7 @@ Rails' concept of MVC dictates that a request is first serviced by a Controller 
 
 The Model Layer, as described by Rails, is responsible for handling the majority of business logic found within the application.  For the vast majority of CRUD applications, this can be the files found within app/models.  We'll talk about methods for obviating Model Bloat later.
 
-Once a Controller has gathered enough information from the Model layer - this information is fed up to a View layer by way of class variables (`@cats = Cat.all`).  This view layer is typically a `.erb` file which leverages standard Ruby syntax intermingled with HTML code.
+Once a Controller has gathered enough information from the Model layer - this information is fed up to a View layer by way of instance variables (`@cats = Cat.all`).  This view layer is typically a `.erb` file which leverages standard Ruby syntax intermingled with HTML code.
 
 This separation gives us clear choices as to the locations of most items and helps to prevent spaghetti code by having different components talking which have no business knowing about each-other.
 


### PR DESCRIPTION
Class variables feature double `@` characters before them and are able to
be accessed, **and changed**, by any common class or subclass. Instance
variables have a single `@` sigil and are only accessible from the current
instance which is why they're used for holding the records in the controller